### PR TITLE
Change EOS node to Atticlab

### DIFF
--- a/statics/config/config.mainnet.json
+++ b/statics/config/config.mainnet.json
@@ -70,7 +70,7 @@
 
 
     "api": {
-        "default_eos_node": "https://api.eossweden.se",
+        "default_eos_node": "https://eosbp.atticlab.net",
         "bpnodes": "https://eosdac.io/topnodes.json",
         "memberclient": "https://toolkit-api.eosdac.io",
         "memberclient_state_api": "https://api-dac.vigor.ai/v1/eosdac",


### PR DESCRIPTION
## Changelog

Change EOS node to Atticlab because EOS sweden reports way too high CPU usage. This leads to transactions like voting on MSIGs, or claiming pay to be denied that would in fact run

[AtticLab Performance](https://www.alohaeos.com/tools/benchmarks)